### PR TITLE
Fix adminTFG key references

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -96,7 +96,7 @@
     "roleNames": {
       "student": "Student",
       "company": "Company",
-      "adminTGF": "TFG Administrator",
+      "adminTFG": "TFG Administrator",
       "adminLink": "Linkage Administrator"
     }
   },
@@ -117,7 +117,7 @@
     "role": {
       "student": "Student",
       "company": "Company",
-      "adminTGF": "TFG Administrator",
+      "adminTFG": "TFG Administrator",
       "adminLink": "Linkage Administrator"
     },
     "actions": {

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -95,7 +95,7 @@
     "roleNames": {
       "student": "Estudiante",
       "company": "Empresa",
-      "adminTGF": "Administrador TFG",
+      "adminTFG": "Administrador TFG",
       "adminLink": "Administrador Vinculación"
     }
   },
@@ -116,7 +116,7 @@
     "role": {
       "student": "Estudiante",
       "company": "Empresa",
-      "adminTGF": "Administrador TFG",
+      "adminTFG": "Administrador TFG",
       "adminLink": "Administrador Vinculación"
     },
     "actions": {

--- a/src/modules/admin/pages/UserManagementPage.tsx
+++ b/src/modules/admin/pages/UserManagementPage.tsx
@@ -71,7 +71,7 @@ const UserManagementPage: React.FC = () => {
           <option value="">{t('userMgmt.filterAll')}</option>
           <option value="student">{t('userMgmt.role.student')}</option>
           <option value="company">{t('userMgmt.role.company')}</option>
-          <option value="adminTGF">{t('userMgmt.role.adminTGF')}</option>
+          <option value="adminTFG">{t('userMgmt.role.adminTFG')}</option>
           <option value="adminLink">{t('userMgmt.role.adminLink')}</option>
         </select>
       </div>


### PR DESCRIPTION
## Summary
- update i18n keys from `adminTGF` to `adminTFG`
- update role filter to use the corrected key

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68433497e610832e8ddf986c50e9f0cf