### PR TITLE
Update Spanish admin translations

### DIFF
--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -71,7 +71,8 @@
     "intro": {
       "student": "Encuentra aquí oportunidades de prácticas y recursos académicos.",
       "company": "Administra tu información de empresa y oferta de servicios.",
-      "admin": "Gestiona usuarios, roles y la configuración del sistema.",
+      "adminTFG": "Gestiona usuarios, roles y la configuración del sistema.",
+      "adminLink": "Gestiona usuarios, roles y la configuración del sistema.",
       "guest": "Por favor inicia sesión o regístrate para continuar."
     }
   },


### PR DESCRIPTION
## Summary
- add `adminTFG` and `adminLink` to Spanish home intro
- remove the obsolete `admin` key

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684334f38f28832eb390fa7f46656346